### PR TITLE
Linked to PHPBenelux's Behavior Policy

### DIFF
--- a/data/phpbenelux-2017.txt
+++ b/data/phpbenelux-2017.txt
@@ -8,6 +8,6 @@ state:
 country:         Belgium
 topics:          PHP, web
 languages:       English
-code_of_conduct: 
+code_of_conduct: https://conference.phpbenelux.eu/2017/behave/
 twitter:         phpbenelux
 facebook:        


### PR DESCRIPTION
Not sure how this was missed, it's linked directly in their menu under `About`
